### PR TITLE
Fix gd2 pod failure

### DIFF
--- a/kubectl_gluster/deploy.py
+++ b/kubectl_gluster/deploy.py
@@ -158,7 +158,7 @@ def glusterd2_setup(config):
     info("glusterd2 pods are UP")
 
     gd2_client_endpoint = "http://gluster-%s-0:24007" % (
-        config["nodes"][0]["address"]
+        config["nodes"][0]["address"].split(".")[0]
     )
 
     def check_num_peers(cmdout):
@@ -168,7 +168,7 @@ def glusterd2_setup(config):
     curl_cmd = "curl %s/v1/peers" % gd2_client_endpoint
     peers = kubectl_exec(
         config["namespace"],
-        "gluster-%s-0" % config["nodes"][0]["address"],
+        "gluster-%s-0" % config["nodes"][0]["address"].split(".")[0],
         curl_cmd,
         out_expect_fn=check_num_peers,
         retries=50,
@@ -193,7 +193,7 @@ def glusterd2_setup(config):
             cmd = "glustercli device add %s %s" % (peer["id"], device)
             kubectl_exec(
                 config["namespace"],
-                "gluster-%s-0" % config["nodes"][0]["address"],
+                "gluster-%s-0" % config["nodes"][0]["address"].split(".")[0],
                 cmd,
                 retries=5,
                 delay=5,


### PR DESCRIPTION
When kube cluster nodes has FQDN hostnames, gd2 pods doesn't
come up. This patch takes care of fix in deployment layer but
the actual fix is gluster/gcs repo.

Signed-off-by: KotreshHR <khiremat@redhat.com>